### PR TITLE
Initialize and validate ckeditor for project summary

### DIFF
--- a/ckeditor-validation-fix.js
+++ b/ckeditor-validation-fix.js
@@ -1,0 +1,100 @@
+// Fixed CKEditor initialization with proper jQuery Validation integration
+ClassicEditor.create(document.querySelector('#ProjectSummary'), {
+    removePlugins: ['CKFinderUploadAdapter', 'CKFinder', 'EasyImage', 'Image', 'ImageCaption', 'ImageStyle', 'ImageToolbar', 'ImageUpload', 'MediaEmbed'],
+    toolbar: [
+        'heading', '|',
+        'bold', 'italic', 'link', '|',
+        'numberedList', 'bulletedList', '|',
+        'insertTable', '|',
+        'undo', 'redo'
+    ],
+    language: 'ar',
+    contentLanguage: 'ar'
+})
+.then(editor => {
+    window.editor = editor;
+    
+    // Get the original textarea element
+    const originalElement = document.querySelector('#ProjectSummary');
+    
+    // Enable manual resizing with CSS - vertical only
+    const editorElement = editor.ui.getEditableElement();
+    editorElement.style.resize = 'vertical';
+    editorElement.style.overflow = 'auto';
+    editorElement.style.height = '75px';
+    editorElement.style.minHeight = '75px';
+    
+    // Exclude CKEditor elements from jQuery validation
+    if (window.jQuery && jQuery.validator) {
+        // Add custom ignore rule for CKEditor elements
+        jQuery.validator.setDefaults({
+            ignore: ".ck-editor__editable, .ck *"
+        });
+        
+        // Ensure the original element has a proper name attribute for validation
+        if (!originalElement.name && originalElement.id) {
+            originalElement.name = originalElement.id;
+        }
+    }
+    
+    // Fix for jQuery Validate - update hidden field on content change
+    editor.model.document.on('change:data', () => {
+        const data = editor.getData();
+        originalElement.value = data;
+        
+        // Trigger validation on the original element only if validator exists
+        if (window.jQuery && jQuery('#ProjectSummary').length > 0) {
+            const form = jQuery('#ProjectSummary').closest('form');
+            const validator = form.data('validator');
+            if (validator) {
+                // Clear any existing errors first
+                validator.resetForm();
+                // Validate the specific element
+                validator.element('#ProjectSummary');
+            }
+        }
+    });
+    
+    // Also update on blur to ensure validation works
+    editor.ui.focusTracker.on('change:isFocused', (evt, data, isFocused) => {
+        if (!isFocused) {
+            const data = editor.getData();
+            originalElement.value = data;
+            
+            if (window.jQuery && jQuery('#ProjectSummary').length > 0) {
+                const form = jQuery('#ProjectSummary').closest('form');
+                const validator = form.data('validator');
+                if (validator) {
+                    // Use setTimeout to ensure the blur event completes first
+                    setTimeout(() => {
+                        validator.element('#ProjectSummary');
+                    }, 100);
+                }
+            }
+        }
+    });
+    
+    // Initial sync of content
+    const initialData = editor.getData();
+    originalElement.value = initialData;
+})
+.catch(err => {
+    console.error('CKEditor initialization error:', err.stack);
+});
+
+// Additional jQuery Validation configuration to handle CKEditor properly
+if (window.jQuery && jQuery.validator) {
+    // Override the default focusout handler to prevent validation errors on CKEditor elements
+    jQuery.validator.defaults.onfocusout = function(element) {
+        // Skip validation for CKEditor elements
+        if (jQuery(element).hasClass('ck-editor__editable') || 
+            jQuery(element).closest('.ck-editor').length > 0) {
+            return;
+        }
+        
+        // Call the original validation logic for other elements
+        if (!this.checkable(element) && (element.name in this.submitted || !this.optional(element))) {
+            this.element(element);
+        }
+    };
+}

--- a/inline-fix-solution.html
+++ b/inline-fix-solution.html
@@ -1,0 +1,118 @@
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/jquery.validation/1.19.5/jquery.validate.min.js"></script>
+<script src="~/ckeditor5-build-classic/ckeditor.js"></script>
+<script src="~/ckeditor5-build-classic/translations/ar.js"></script>
+<script src="~/js/publishandsurviey/create.js" asp-append-version="true"></script>
+<script>
+    // Configure jQuery Validation to ignore CKEditor elements BEFORE initializing CKEditor
+    if (window.jQuery && jQuery.validator) {
+        jQuery.validator.setDefaults({
+            ignore: ".ck-editor__editable, .ck *, [contenteditable='true']"
+        });
+        
+        // Override the focusout handler to prevent validation errors on CKEditor elements
+        const originalFocusout = jQuery.validator.defaults.onfocusout;
+        jQuery.validator.defaults.onfocusout = function(element) {
+            // Skip validation for CKEditor elements
+            if (jQuery(element).hasClass('ck-editor__editable') || 
+                jQuery(element).closest('.ck-editor').length > 0 ||
+                jQuery(element).attr('contenteditable') === 'true') {
+                return;
+            }
+            
+            // Call the original validation logic for other elements
+            if (originalFocusout) {
+                originalFocusout.call(this, element);
+            } else {
+                if (!this.checkable(element) && (element.name in this.submitted || !this.optional(element))) {
+                    this.element(element);
+                }
+            }
+        };
+    }
+
+    ClassicEditor.create(document.querySelector('#ProjectSummary'), {
+        removePlugins: ['CKFinderUploadAdapter', 'CKFinder', 'EasyImage', 'Image', 'ImageCaption', 'ImageStyle', 'ImageToolbar', 'ImageUpload', 'MediaEmbed'],
+        toolbar: [
+            'heading', '|',
+            'bold', 'italic', 'link', '|',
+            'numberedList', 'bulletedList', '|',
+            'insertTable', '|',
+            'undo', 'redo'
+        ],
+        language: 'ar',
+        contentLanguage: 'ar'
+    })
+    .then(editor => {
+        window.editor = editor;
+        
+        // Get the original element
+        const originalElement = document.querySelector('#ProjectSummary');
+        
+        // Ensure the original element has a name attribute for validation
+        if (!originalElement.name && originalElement.id) {
+            originalElement.name = originalElement.id;
+        }
+
+        // Enable manual resizing with CSS - vertical only
+        const editorElement = editor.ui.getEditableElement();
+        editorElement.style.resize = 'vertical';
+        editorElement.style.overflow = 'auto';
+        editorElement.style.height = '75px';
+        editorElement.style.minHeight = '75px';
+        
+        // Fix for jQuery Validate - update hidden field on content change
+        editor.model.document.on('change:data', () => {
+            const data = editor.getData();
+            originalElement.value = data;
+
+            // Trigger validation on the original element with safety checks
+            if (window.jQuery && jQuery('#ProjectSummary').length > 0) {
+                const $element = jQuery('#ProjectSummary');
+                const form = $element.closest('form');
+                const validator = form.data('validator');
+                
+                if (validator && typeof validator.element === 'function') {
+                    try {
+                        validator.element($element[0]);
+                    } catch (e) {
+                        console.warn('Validation error caught and ignored:', e);
+                    }
+                }
+            }
+        });
+
+        // Also update on blur to ensure validation works
+        editor.ui.focusTracker.on('change:isFocused', (evt, data, isFocused) => {
+            if (!isFocused) {
+                const data = editor.getData();
+                originalElement.value = data;
+
+                if (window.jQuery && jQuery('#ProjectSummary').length > 0) {
+                    const $element = jQuery('#ProjectSummary');
+                    const form = $element.closest('form');
+                    const validator = form.data('validator');
+                    
+                    if (validator && typeof validator.element === 'function') {
+                        // Use setTimeout to ensure the blur event completes first
+                        setTimeout(() => {
+                            try {
+                                validator.element($element[0]);
+                            } catch (e) {
+                                console.warn('Validation error caught and ignored:', e);
+                            }
+                        }, 100);
+                    }
+                }
+            }
+        });
+        
+        // Initial sync of content
+        const initialData = editor.getData();
+        originalElement.value = initialData;
+    })
+    .catch(err => {
+        console.error('CKEditor initialization error:', err.stack);
+    });
+</script>


### PR DESCRIPTION
Fixes "Cannot read properties of undefined (reading 'replace')" error when using jQuery Validation with CKEditor.

The error occurred because jQuery Validation attempted to process CKEditor's dynamically generated contenteditable divs, which lack the necessary `name` attributes expected by the validation plugin's internal functions. This PR configures jQuery Validation to ignore these elements and ensures the original textarea is correctly validated.

---
<a href="https://cursor.com/background-agent?bcId=bc-82cbc550-999c-4869-9fce-9f0a076cbc3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82cbc550-999c-4869-9fce-9f0a076cbc3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

